### PR TITLE
Passage de pxc_strict_mode à PERMISSIVE par défaut

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,6 @@ pxc_datadir: /var/lib/mysql
 
 pxc_root_password: "changeme"
 
-pxc_strict_mode: ENFORCING
+pxc_strict_mode: PERMISSIVE 
 
 pxc_version: "5.6"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,6 +58,6 @@ pxc_datadir: /var/lib/mysql
 
 pxc_root_password: "changeme"
 
-pxc_strict_mode: PERMISSIVE 
+pxc_strict_mode: PERMISSIVE
 
 pxc_version: "5.6"


### PR DESCRIPTION
Passage de `pxc_strict_mode` à `PERMISSIVE` par défaut étant donné que c'est la configuration la plus commune. Possible de changer à `ENFORCING`, `MASTER` ou `DISABLED` dans l'inventaire de chaque config.